### PR TITLE
Create releaseArtifacts.yaml

### DIFF
--- a/.github/workflows/releaseArtifacts.yaml
+++ b/.github/workflows/releaseArtifacts.yaml
@@ -1,0 +1,63 @@
+name: release
+run-name: ${{ github.repository }}'s Release Artifacts
+on: 
+  release: 
+    types: 
+      - published
+  workflow_dispatch:
+jobs:
+  release:
+    name: Release - ${{ matrix.platform.release_for }}
+    strategy:
+      matrix:
+        platform:
+          - release_for: Linux-x86_64
+            os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            bin: testing_api
+            name: testing_api-Linux-x86_64.tar.gz
+            command: build
+            path: target/x86_64-unknown-linux-gnu/release
+
+          - release_for: Windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bin: testing_api.exe
+            name: testing_api-Windows-x86_64.zip
+            command: both
+            path: target/x86_64-pc-windows-msvc/release
+
+          - release_for: MacOS-x86_64
+            os: macOS-latest
+            target: x86_64-apple-darwin
+            bin: testing_api
+            name: testing_api-Darwin-x86_64.tar.gz
+            command: both
+            path: target/x86_64-apple-darwin/release
+            # more release targets here ...
+
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Binary
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: ${{ matrix.platform.command }}
+          target: ${{ matrix.platform.target }}
+          args: "--release"
+          strip: true
+      - name: Rename Binary
+        run: ${{ matrix.platform.rename }}
+      - name: Get Release
+        id: release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ github.repository }}
+      - name: Release Binary
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "${{ matrix.platform.path }}/${{ matrix.platform.bin }}"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-id: ${{ steps.release.outputs.id }}
+          


### PR DESCRIPTION
Release artifacts on release publish, builds binaries and attatches them to github repo release, built from [NotLiam99/TestingApi](https://github.com/Notliam99/TestingApi)  main (Protected) branch.

[Enchancment - Release Artifact Action](https://github.com/Notliam99/TestingApi/issues/25) #25 