### PR TITLE
update to the formating of the logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,10 @@ async fn main() {
             .service(paths::hello)
             .service(paths::json_hello)
             .service(paths::qparams_hello)
-            .wrap(Logger::new("Ip: ( %a ), Path: ( %U ), Latency: ( %Dms )")) // Logging
+            .wrap(
+                Logger::new("Response: [%s], Ip: ( %{r}a ), Path: ( %U ), Latency: ( %Dms )")
+                    .log_target("Http_Logs"),
+            ) // Logging
     })
     .bind(("0.0.0.0", args::check_port().unwrap()))
     .unwrap()


### PR DESCRIPTION
# Reformat
I have reformatted the logging adding realIp and Response codes. I also changed what is called the log_target before it was a back trace now its just a simple tag.

### From:
```
[2024-04-27T04:29:19Z INFO  actix_web::middleware::logger] Ip: ( 127.0.0.1 ), Path: ( / ), Latency: ( 0.089201ms )
```
### Now:
```
[2024-04-27T04:36:55Z INFO  Http_Logs] Response: [404], Ip: ( 127.0.0.1 ), Path: ( / ), Latency: ( 0.147570ms )
```
