### PR TITLE
Port Arg Fuction Rewrite

### DIFF
--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -1,33 +1,75 @@
-use std::io;
+use std::{env, net::TcpListener};
 
-///
-/// This function checks for the -p or --port flags and returns a unsigned 16 int aka the arg
+fn port_is_available(port: u16) -> bool {
+    match TcpListener::bind(("127.0.0.1", port)) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+/// # Arg_Port
+/// This function checks for the -p or --port flags and returns a unsigned 16 int aka the port
+/// number. It also verifys that the port is avalible.
 ///
 /// # Examples
 ///
 /// ```
-/// use testing_api::args::check_port;
+/// # #[cfg(test)]
+/// # mod test {
+/// # #[test]
+/// # fn test() {
+/// use testing_api::args::arg_port;
 ///
-/// assert_eq!(check_port().unwrap(), 8080u16);
+/// panic_unless!(arg_port() == 8000u16)
+/// # }}
 /// ```
-pub fn check_port() -> Result<u16, io::Error> {
-    let default_port: u16 = 8080;
-    let args: Vec<String> = std::env::args().collect();
-    // iterate through arguements checking for port arguement
-    for (index, arg) in args.iter().enumerate() {
-        if arg == "-p" || arg == "--port" {
-            // check if a arguement exists after -p
-            if let Some(port_str) = args.get(index + 1) {
-                /* if string converts to unsigned 16 int then return the port
-                otherwise error etc. default to default_port */
-                if let Ok(port) = port_str.parse::<u16>() {
-                    println!("Port set to {}", port);
-                    return Ok(port);
+pub fn arg_port() -> u16 {
+    let default_port: u16 = if cfg!(test) {
+        8000u16
+    } else {
+        (8000..9000)
+            .find(|port| port_is_available(*port))
+            .expect("Could Not Find A Open Port")
+    }; // Finds A Available Port On the System
+
+    let args: Vec<String> = env::args().collect();
+
+    match args.len() {
+        1 => {
+            // no args are set
+            return default_port;
+        }
+        2 => {
+            // one pram is set with no value
+            if args[1] == "-p" || args[1] == "--port" {
+                println!("Parameter Must Have VALUE eg. `--port {default_port}`\n");
+            } else {
+                println!(
+                    "Parameter {} Not Recognised Only Accept `-p` And `--port`\n",
+                    args[1]
+                )
+            }
+            return default_port;
+        }
+        _ => {
+            // a pram and a value is set
+            for (index, item) in args.iter().enumerate() {
+                if item == "-p" || item == "--port" {
+                    let port = args
+                        .get(index + 1)
+                        .unwrap()
+                        .parse::<u16>()
+                        .unwrap_or(default_port);
+
+                    if !port_is_available(port) || cfg!(test) {
+                        println!("Port Was Not Avalible Using Port: ( {default_port} )\n");
+                        return default_port;
+                    }
+
+                    return port;
                 }
             }
+            return default_port;
         }
     }
-    // if there are no arguments return default port
-    println!("No valid port specified defaulting to {}", default_port);
-    return Ok(default_port);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
             .service(paths::qparams_hello)
             .wrap(Logger::new("Ip: ( %a ), Path: ( %U ), Latency: ( %Dms )")) // Logging
     })
-    .bind(("0.0.0.0", args::check_port().unwrap()))
+    .bind(("0.0.0.0", args::arg_port()))
     .unwrap()
     .run()
     .await


### PR DESCRIPTION
# Different How
I have rewrote the port argument parser to catch invalid ports. For example another app could be using the port the service wants to connect to. If this were to happen it will fall over to a port that's been checked to be available. It verifies this by running a Listener on the port briefly to check if its available.

## Benefits
It gives quick understandable feedback to the user.