### PR TITLE
swagger-ui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ licenceFile = "./LICENSE"
 actix-web = "4.5.1"
 env_logger = "0.11.3"
 serde = { version = "1.0.197", features = ["derive"] }
+utoipa = { version = "4.2.0", features = ["actix_extras"] }
+utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,19 @@
 use actix_web::{middleware::Logger, App, HttpServer};
 use testing_api::{args, paths};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
 #[actix_web::main]
 async fn main() {
     // init the logger
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    #[derive(OpenApi)]
+    #[openapi(
+        paths(paths::hello, paths::json_hello, paths::qparams_hello),
+        components(schemas(paths::Message))
+    )]
+    struct ApiDoc;
 
     // Start the api server with port helper (args::check_port())
     HttpServer::new(|| {
@@ -12,6 +21,9 @@ async fn main() {
             .service(paths::hello)
             .service(paths::json_hello)
             .service(paths::qparams_hello)
+            .service(
+                SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", ApiDoc::openapi()),
+            )
             .default_service(actix_web::web::to(paths::catch_all))
             .wrap(
                 Logger::new("Response: [%s], Ip: ( %{r}a ), Path: ( %U ), Latency: ( %Dms )")

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -1,7 +1,13 @@
 use actix_web::{get, web, HttpResponse, Responder, Result};
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
 // returns path parameter "name" as plain text
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Valid Name Entered"),
+    ),
+)]
 #[get("/hello/plain/{name}")]
 pub async fn hello(name: web::Path<String>) -> impl Responder {
     // responds with the below text and path parameter "name" which the user chooses
@@ -9,12 +15,17 @@ pub async fn hello(name: web::Path<String>) -> impl Responder {
 }
 
 // Creates message object for json responses
-#[derive(Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct Message {
     pub hello: String,
 }
 
 // returns path parameter "name" as json object
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Valid Name Entered", body = Message)
+    ),
+)]
 #[get("/hello/json/{name}")]
 pub async fn json_hello(name: web::Path<String>) -> Result<web::Json<Message>> {
     // creates object message
@@ -25,11 +36,20 @@ pub async fn json_hello(name: web::Path<String>) -> Result<web::Json<Message>> {
     Ok(web::Json(message))
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, IntoParams)]
 pub struct HelloParams {
     pub name: String,
 }
 
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Valid Name Pram"),
+        (status = 400, description = "Invalid Request Missing `name` Param")
+    ),
+    params(
+        HelloParams
+    )
+)]
 #[get("/hello/qparams")]
 pub async fn qparams_hello(params: web::Query<HelloParams>) -> HttpResponse {
     // responds with the json object 'Message


### PR DESCRIPTION
# Swagger UI
I used a couple creates to do this _[utoipa-swagger-ui](https://crates.io/crates/utoipa-swagger-ui)_ and _[utoipa](https://crates.io/crates/utoipa)_ to document the api routes.

## defining routes
**The Path Code**
```rust
#[utoipa::path(
    responses(
        (status = 200, description = "Valid Name Entered"),
    ),
)]
#[get("/hello/plain/{name}")]
pub async fn hello(name: web::Path<String>) -> impl Responder {
    // responds with the below text and path parameter "name" which the user chooses
    format!("Hello {name} Your A Monkey! 🦍")
}
```
**The `main.rs`**
```rust
// imports
use actix_web::{App, HttpServer};
use utoipa::OpenApi;
use utoipa_swagger_ui::SwaggerUi;

// path functions
...

fn main() {    
    #[derive(OpenApi)]
    #[openapi(
        paths(paths::hello, paths::json_hello, paths::qparams_hello),
        components(schemas(paths::Message))
    )]
    struct ApiDoc;

    // Start the api server with port helper (args::check_port())
    HttpServer::new(|| {
        App::new()
            ...
            .service(hello)
            .service(
                SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", ApiDoc::openapi()),
            )
        })
        ...
}
```
---
![Screen Shot 2024-05-03 at 11 01 11](https://github.com/Notliam99/TestingApi/assets/95384035/de5cf8f8-ca6e-421d-9bb3-3cfbb073d81b)

